### PR TITLE
feat(scaffold): add mobile-design Expo app scaffold

### DIFF
--- a/Design/mobile-design/README.md
+++ b/Design/mobile-design/README.md
@@ -1,0 +1,18 @@
+# mobile-design (scaffold)
+
+This folder is a small scaffold for a mobile app using the same tech choices as the repo's `apps/mobile` package (Expo + React Native + TypeScript + Jest).
+
+What's included:
+
+- `src/` — minimal Expo app (`App.tsx`, entry `index.tsx`)
+- `lib/` — small helper
+- `__tests__/` — sample Jest test
+- `package.json` & `tsconfig.json` — minimal scripts and config to match the monorepo conventions
+
+To finish setup:
+
+1. From the repo root, add this package to your workspace (if desired) in `package.json` workspaces.
+2. Run your package manager (npm/pnpm/yarn) to install dependencies.
+3. Run `npm run start` from this folder to start the Expo dev tools (after installing dependencies).
+
+If you want, I can add `mobile-design` to the monorepo `workspaces` in the root `package.json` and run an initial `npm install` for you.

--- a/Design/mobile-design/__tests__/lib.test.ts
+++ b/Design/mobile-design/__tests__/lib.test.ts
@@ -1,0 +1,5 @@
+import { add } from '../lib';
+
+test('adds two numbers', () => {
+  expect(add(1, 2)).toBe(3);
+});

--- a/Design/mobile-design/lib/index.ts
+++ b/Design/mobile-design/lib/index.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/Design/mobile-design/package.json
+++ b/Design/mobile-design/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mobile-design",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,json}\"",
+    "check": "npm run lint && npm run typecheck && npm run test -- --watchAll=false"
+  },
+  "privateConfig": {
+    "scaffoldedFrom": "apps/mobile"
+  }
+}

--- a/Design/mobile-design/src/App.tsx
+++ b/Design/mobile-design/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{flex:1,alignItems:'center',justifyContent:'center'}}>
+      <Text>mobile-design scaffold — hello 👋</Text>
+    </View>
+  );
+}

--- a/Design/mobile-design/src/index.tsx
+++ b/Design/mobile-design/src/index.tsx
@@ -1,0 +1,5 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+// registerRootComponent ensures the app is initialized whether in Expo or native environment
+registerRootComponent(App);

--- a/Design/mobile-design/tsconfig.json
+++ b/Design/mobile-design/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": "./"
+  },
+  "include": ["src", "lib"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Add a small Expo + React Native + TypeScript scaffold under Design/mobile-design:
src/ (App.tsx, index.tsx)
lib/ (index.ts)
__tests__/ (lib.test.ts)
package.json, tsconfig.json, README.md
Update .gitignore to allow Design/mobile-design/__tests__ and add a sample test.
Commit summary:
scaffold: add mobile-design app scaffold (src, lib, tests)
test: add sample test for mobile-design
Notes:
The scaffold mirrors the repo's apps/mobile tech choices (Expo, Jest, TypeScript).
To integrate with monorepo installs, add Design/mobile-design to root package.json workspaces and run the package manager install.
How to test locally:
From repo root: npm install
cd Design/mobile-design
npm run start (Expo) or npm run test (Jest)